### PR TITLE
Real priority

### DIFF
--- a/src/kernel/pm/sched.c
+++ b/src/kernel/pm/sched.c
@@ -65,7 +65,7 @@ PUBLIC void resume(struct process *proc)
 //Get real priority
 PUBLIC int get_realprio(struct process *proc){
 	int counter_prio = proc->counter >> 1;
-	return (-proc->priority) + proc->nice + counter_prio;
+	return counter_prio - proc->nice - proc->priority;
 }
 
 /**

--- a/src/kernel/pm/sched.c
+++ b/src/kernel/pm/sched.c
@@ -65,7 +65,7 @@ PUBLIC void resume(struct process *proc)
 //Get real priority
 PUBLIC int get_realprio(struct process *proc){
 	int counter_prio = proc->counter >> 1;
-	return proc->priority + proc->nice + counter_prio;
+	return (-proc->priority) + proc->nice + counter_prio;
 }
 
 /**

--- a/src/sbin/test/test.c
+++ b/src/sbin/test/test.c
@@ -226,9 +226,14 @@ static void work_io(void)
  *
  * @return Zero if passed on test, and non-zero otherwise.
  */
-static int sched_test0(void)
+static int sched_test0(clock_t *ttotal)
 {
 	pid_t pid;
+
+	struct tms timing; /* Timing information. */
+	clock_t t0, t1;  
+
+	t0 = times(&timing);
 
 	pid = fork();
 
@@ -244,6 +249,10 @@ static int sched_test0(void)
 	}
 
 	wait(NULL);
+	
+	t1 = times(&timing);
+
+	*ttotal = t1-t0;
 
 	return (0);
 }
@@ -256,9 +265,14 @@ static int sched_test0(void)
  *
  * @returns Zero if passed on test, and non-zero otherwise.
  */
-static int sched_test1(void)
+static int sched_test1(clock_t *ttotal)
 {
 	pid_t pid;
+
+	struct tms timing; /* Timing information. */
+	clock_t t0, t1;  
+
+	t0 = times(&timing);
 
 	pid = fork();
 
@@ -282,6 +296,10 @@ static int sched_test1(void)
 	}
 
 	wait(NULL);
+	
+	t1 = times(&timing);
+
+	*ttotal = t1-t0;
 
 	return (0);
 }
@@ -293,9 +311,14 @@ static int sched_test1(void)
  *
  * @returns Zero if passed on test, and non-zero otherwise.
  */
-static int sched_test2(void)
+static int sched_test2(clock_t *ttotal)
 {
 	pid_t pid[4];
+
+	struct tms timing; /* Timing information. */
+	clock_t t0, t1;  
+
+	t0 = times(&timing);
 
 	for (int i = 0; i < 4; i++)
 	{
@@ -335,6 +358,10 @@ static int sched_test2(void)
 			wait(NULL);
 		}
 	}
+	
+	t1 = times(&timing);
+
+	*ttotal = t1-t0;
 
 	return (0);
 }
@@ -346,10 +373,15 @@ static int sched_test2(void)
  *
  * @returns Zero if passed on test, and non-zero otherwise.
  */
-static int sched_test3(void)
+static int sched_test3(clock_t *ttotal)
 {
 	pid_t child;
 	pid_t father;
+
+	struct tms timing; /* Timing information. */
+	clock_t t0, t1;  
+
+	t0 = times(&timing);
 
 	father = getpid();
 
@@ -365,6 +397,10 @@ static int sched_test3(void)
 	/* Die. */
 	if (getpid() != father)
 		_exit(EXIT_SUCCESS);
+	
+	t1 = times(&timing);
+
+	*ttotal = t1-t0;
 
 	return (0);
 }
@@ -639,13 +675,26 @@ int main(int argc, char **argv)
 		/* Scheduling test. */
 		else if (!strcmp(argv[i], "sched"))
 		{
+			clock_t ttotal, tparcial;
+
 			printf("Scheduling Tests\n");
+
 			printf("  waiting for child  [%s]\n",
-				(!sched_test0()) ? "PASSED" : "FAILED");
+				(!sched_test0(&tparcial)) ? "PASSED" : "FAILED");
+			printf("  	Elapsed time: %d\n", tparcial);
+			ttotal += tparcial;
+
 			printf("  dynamic priorities [%s]\n",
-				(!sched_test1()) ? "PASSED" : "FAILED");
+				(!sched_test1(&tparcial)) ? "PASSED" : "FAILED");
+			printf("  	Elapsed time: %d\n", tparcial);
+			ttotal += tparcial;
+
 			printf("  scheduler stress   [%s]\n",
-				(!sched_test2() && !sched_test3()) ? "PASSED" : "FAILED");
+				(!sched_test2(&tparcial) && !sched_test3(&tparcial)) ? "PASSED" : "FAILED");
+			printf("  	Elapsed time: %d\n", tparcial);
+			ttotal += tparcial;
+
+			printf("\n  Total elapsed time: %d\n", ttotal);
 		}
 
 		/* IPC test. */

--- a/tools/dev/setup/qemu.sh
+++ b/tools/dev/setup/qemu.sh
@@ -23,7 +23,7 @@ function setup_qemu
 {
     local TARGET="$1-softmmu"
     local PREFIX=$2/qemu
-    local VERSION=8.0.0
+    local VERSION=8.1.1
 
     pushd $PWD
 


### PR DESCRIPTION
Troquei a lógica para obter a prioridade de processo, levando em consideração o counter, nice e priority,  para a que acredito ser a mais correta.

 Na primeira versão, feita pelo @rafael0121 a lógica estava assim:
`return counter_prio - proc->nice - proc->priority;`
Dessa forma, o counter é o que tem mais peso sobre a conta, pois ele pode assumir valores mais extremos, mesmo que o nice e o priority tenham mais relevância.

Mudei para isso:
`return counter_prio - proc->nice - proc->priority;`
Assim, o nice e o priority assumem um papel mais importante para a lógica, pois assim, quem tiver o maior valor, será executado primeiro.